### PR TITLE
Add set_version input to sdk_generation workflow

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -24,6 +24,7 @@ jobs:
       force: ${{ github.event.inputs.force }}
       mode: pr
       speakeasy_version: latest
+      set_version: ${{ github.event.inputs.set_version }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK generation workflow to accept an optional set_version input when manually triggered, enabling pinning a specific SDK version during runs.
  * Forwards the set_version value to the SDK generation action.
  * No changes to existing inputs, secrets, or automated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->